### PR TITLE
Rework and shorten tracking changes lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ Please help us keep track of all the workshops taught with this material:
 This helps us show the impact of developing open-source lessons to our funders.
 
 ## Carpentries Workbench
-This lesson is a template lesson that uses The Carpentries Workbench.
-Checkout the [documentation of The Carpentries Workbench][workbench] on how to build/serve the lesson locally and how to adapt it.
+This lesson is a template lesson that uses The Carpentries Workbench. How to use and install the workbench can be found [here](https://carpentries.github.io/workbench/).
+Once you have installed the workbench, run the following command in an R shell:
+
+`sandpaper::serve()`
+
+More extensive information on how to build/serve the lesson locally and how to adapt it can be found in the [documentation of The Carpentries Workbench][workbench].
 
 
 [workbench]: https://carpentries.github.io/sandpaper-docs/

--- a/episodes/03-create.md
+++ b/episodes/03-create.md
@@ -168,48 +168,6 @@ fatal: Not a git repository (or any of the parent directories): .git
 
 :::::::::::::::::::::::::
 
-## Correcting `git init` Mistakes
-
-Wolfman explains to Dracula how a nested repository is redundant and may cause confusion
-down the road. Dracula would like to remove the nested repository. How can Dracula undo
-his last `git init` in the `moons` subdirectory?
-
-:::::::::::::::  solution
-
-## Solution -- USE WITH CAUTION!
-
-### Background
-
-Removing files from a Git repository needs to be done with caution. But we have not learned
-yet how to tell Git to track a particular file; we will learn this in the next episode. Files
-that are not tracked by Git can easily be removed like any other "ordinary" files with
-
-```bash
-$ rm filename
-```
-
-Similarly a directory can be removed using `rm -r dirname` or `rm -rf dirname`.
-If the files or folder being removed in this fashion are tracked by Git, then their removal
-becomes another change that we will need to track, as we will see in the next episode.
-
-### Solution
-
-Git keeps all of its files in the `.git` directory.
-To recover from this little mistake, Dracula can just remove the `.git`
-folder in the moons subdirectory by running the following command from inside the `planets` directory:
-
-```bash
-$ rm -rf moons/.git
-```
-
-But be careful! Running this command in the wrong directory will remove
-the entire Git history of a project you might want to keep.
-Therefore, always check your current directory using the command `pwd`.
-
-
-
-:::::::::::::::::::::::::
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::: keypoints

--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -732,20 +732,17 @@ $ git commit -m "Write plans to start a base on Venus"
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
+:::::::::::::::::::::::::::::::::::::::: instructor
 ## Ignoring Things
 
-:::::::::::::::::::::::::::::::::::::::: instructor
-There are no slides associated with this section. 
+This is an optional aside if it comes up or if there is enough time to address it. 
 
-Explain the concept of ignoring files with a .gitignore file briefly and direct learners to additional resources.
-::::::::::::::::::::::::::::::::::::::::::::::::::
+Briefly mention the concept of ignoring files with a .gitignore file and direct learners to additional resources.
 
-What if we have files that we do not want Git to track for us, like backup files created by our editor or intermediate files created during data analysis? 
+Along the lines of "What if we have files that we do not want Git to track for us, like backup files created by our editor or intermediate files created during data analysis? 
 Putting these files under version control would be a waste of disk space. What’s worse, having them all listed could distract us from changes that actually matter, so we can tell Git to ignore them.
-
-We can do this by creating a file in the root directory of our project called `.gitignore`
-
-As a bonus, using `.gitignore` helps us avoid accidentally adding files to the repository that we don’t want to track.
+We can do this by creating a file in the root directory of our project called `.gitignore`. As a bonus, using `.gitignore` helps us avoid accidentally adding files to the repository that we don’t want to track."
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 [commit-messages]: https://chris.beams.io/posts/git-commit/

--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -731,58 +731,6 @@ $ git commit -m "Write plans to start a base on Venus"
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::  challenge
-
-## `bio` Repository
-
-- Create a new Git repository on your computer called `bio`.
-- Write a three-line biography for yourself in a file called `me.txt`,
-  commit your changes
-- Modify one line, add a fourth line
-- Display the differences
-  between its updated state and its original state.
-
-:::::::::::::::  solution
-
-## Solution
-
-If needed, move out of the `planets` folder:
-
-```bash
-$ cd ..
-```
-
-Create a new folder called `bio` and 'move' into it:
-
-```bash
-$ mkdir bio
-$ cd bio
-```
-
-Initialise git:
-
-```bash
-$ git init
-```
-
-Create your biography file `me.txt` using `nano` or another text editor.
-Once in place, add and commit it to the repository:
-
-```bash
-$ git add me.txt
-$ git commit -m "Add biography file" 
-```
-
-Modify the file as described (modify one line, add a fourth line).
-To display the differences
-between its updated state and its original state, use `git diff`:
-
-```bash
-$ git diff me.txt
-```
-
-:::::::::::::::::::::::::
-::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Ignoring Things
 

--- a/episodes/04-changes.md
+++ b/episodes/04-changes.md
@@ -782,8 +782,7 @@ $ git diff me.txt
 ```
 
 :::::::::::::::::::::::::
-
-:::::::::::::::::::::::::::::::::::::::::  callout
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Ignoring Things
 
@@ -793,10 +792,12 @@ There are no slides associated with this section.
 Explain the concept of ignoring files with a .gitignore file briefly and direct learners to additional resources.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::::::::: 
+What if we have files that we do not want Git to track for us, like backup files created by our editor or intermediate files created during data analysis? 
+Putting these files under version control would be a waste of disk space. What’s worse, having them all listed could distract us from changes that actually matter, so we can tell Git to ignore them.
 
-::::::::::::::::::::::::::::::::::::::::::::::::::
+We can do this by creating a file in the root directory of our project called `.gitignore`
 
+As a bonus, using `.gitignore` helps us avoid accidentally adding files to the repository that we don’t want to track.
 
 
 [commit-messages]: https://chris.beams.io/posts/git-commit/
@@ -811,6 +812,7 @@ Explain the concept of ignoring files with a .gitignore file briefly and direct 
 - `git commit` saves the staged content as a new commit in the local repository.
 - `git log` shows the commit history & `git diff` the difference between 2 commits.
 - Write a commit message that accurately describes your changes.
+- Introduce the concept of a `.gitignore` file
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
Added mentions to both git revert and .gitignore into the lesson. 
I am not sure where is the best place for the .gitignore section should be and if a short exercise adding a .gitignore file would be useful. I think it could perhaps be moved to the remotes in git section. The branches section also seems a little disconnected? 

I went through it otherwise and it seems to flow ok, although some explanations are little long. I think it might be useful if you go through it to see if anything else needs adapting. 

Still to do:
- [x] Make sure the lesson flows properly
- [x] Fix the formatting
- [x] Choose exercises we want to keep
- [ ] Make explanations more succinct